### PR TITLE
Convenience method to join the communications thread

### DIFF
--- a/ixcom/parser.py
+++ b/ixcom/parser.py
@@ -223,6 +223,18 @@ class Client(MessageParser):
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         self.sock.connect((self.host, self.port))
 
+    def join_comm_thread(self):
+        '''Join the communication thread
+
+        Blocks the calling location until the communications thread terminates.
+        Can e.g. be used if callbacks have been set up, logs have been requested and we just want to
+        leave the program running like this until the communications with the device stop.
+
+        Args:
+            self
+        '''
+        self._comm_thread.join()
+
     def stop(self):
         self._stop_event.set()
         self._comm_thread.join()


### PR DESCRIPTION
This PR adds a convenience method to the Client class to join the communications thread, usage scenario as follows:

```
def msg_callback(msg, from_device):
    pass

ixcom_client = ixcom.Client(192.168.1.30, port=3001)
ixcom_client.open_last_free_channel()
ixcom_client.clear_all()
ixcom_client.add_log_with_rate(ixcom.data.WHEELDATA_Payload.message_id, 10.0)
ixcom_client.add_callback(msg_callback)
ixcom_client.join_comm_thread()
```