### PR TITLE
Adjust size of PARSYS_SYSNAME parameter

### DIFF
--- a/ixcom/parameters.py
+++ b/ixcom/parameters.py
@@ -14,6 +14,11 @@ class PARSYS_STRING64_Payload(DefaultParameterPayload):
         PayloadItem(name = 'str', dimension = 64, datatype = 's')
     ])
 
+class PARSYS_STRING128_Payload(DefaultParameterPayload):
+    parameter_payload = Message([
+        PayloadItem(name = 'str', dimension = 128, datatype = 's')
+    ])
+
 @parameter(0)
 class PARSYS_PRJNUM_Payload(PARSYS_STRING_Payload):
     pass
@@ -110,7 +115,7 @@ class PARSYS_OSVERSION_Payload(PARSYS_STRING64_Payload):
     pass
 
 @parameter(19)
-class PARSYS_SYSNAME_Payload(PARSYS_STRING64_Payload):
+class PARSYS_SYSNAME_Payload(PARSYS_STRING128_Payload):
     pass
 
 """


### PR DESCRIPTION
This PR adjusts the size of the PARSYS_SYSNAME parameter to 128 characters, which seems to be the new length.﻿
